### PR TITLE
Update to 1.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,6 @@ group = project.maven_group
 
 repositories {
 	maven { url 'https://jitpack.io' }
-	mavenLocal()
-	maven { url 'https://jcenter.bintray.com/' }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-	id 'fabric-loom' version '0.5-SNAPSHOT'
+	id 'fabric-loom' version '0.8-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -12,6 +12,8 @@ group = project.maven_group
 
 repositories {
 	maven { url 'https://jitpack.io' }
+	mavenLocal()
+	maven { url 'https://jcenter.bintray.com/' }
 }
 
 dependencies {
@@ -42,7 +44,7 @@ tasks.withType(JavaCompile).configureEach {
 	// The Minecraft launcher currently installs Java 8 for users, so your mod probably wants to target Java 8 too
 	// JDK 9 introduced a new way of specifying this that will make sure no newer classes or methods are used.
 	// We'll use that if it's available, but otherwise we'll use the older option.
-	def targetVersion = 8
+	def targetVersion = 16
 	if (JavaVersion.current().isJava9Compatible()) {
 		 it.options.release = targetVersion
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.16.5
-	yarn_mappings=1.16.5+build.1
-	loader_version=0.11.0
+	minecraft_version=1.17
+	yarn_mappings=1.17+build.13
+	loader_version=0.11.6
 
 # Mod Properties
-	mod_version = 1.0.0
+	mod_version = 1.1.0
 	maven_group = nl.theepicblock
 	archives_base_name = polypuck
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.29.3+1.16
-	polymc_version=3.1.0
+	fabric_version=0.36.0+1.17
+	polymc_version=3.1.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,5 +5,6 @@ pluginManagement {
             url = 'https://maven.fabricmc.net/'
         }
         gradlePluginPortal()
+        mavenLocal()
     }
 }

--- a/src/main/java/nl/theepicblock/polypuck/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/nl/theepicblock/polypuck/mixin/ServerPlayerEntityMixin.java
@@ -3,6 +3,7 @@ package nl.theepicblock.polypuck.mixin;
 import io.github.theepicblock.polymc.api.misc.PolyMapProvider;
 import io.github.theepicblock.polymc.impl.NOPPolyMap;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ServerPlayerEntity.class)
 public class ServerPlayerEntityMixin {
 	@Inject(method = "sendResourcePackUrl", at = @At("HEAD"), cancellable = true)
-	private void resourcePackInject(String url, String hash, CallbackInfo ci) {
+	private void resourcePackInject(String url, String hash, boolean required, Text resourcePackPrompt, CallbackInfo ci) {
 		if (PolyMapProvider.getPolyMap((ServerPlayerEntity)(Object)this) instanceof NOPPolyMap) {
 			ci.cancel();
 		}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,7 +30,8 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.4",
-    "fabric": "*"
+    "fabricloader": ">=0.11.6",
+    "fabric": "*",
+    "java": ">=16"
   }
 }

--- a/src/main/resources/polypuck.mixins.json
+++ b/src/main/resources/polypuck.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "nl.theepicblock.polypuck.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_16",
   "server": [
     "ServerPlayerEntityMixin"
   ],


### PR DESCRIPTION
Updated java and dependencies (FAPI and Mixins)

With some incompatible mods (eg. DankStorage) the client will just crash from the server without logging (or a message) from the client or the server; i tried to iron this bug out but I can't find the right motivation, but it's obviously triggered when the client recives the PolyMap.